### PR TITLE
Create container-interop service provider (to use in core) and Puli binding-type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor/
 .php_cs.cache
 build/
+.puli

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,17 @@
     "require": {
         "php": ">=5.5.0",
         "ext-openssl": "*",
-        "webmozart/assert": "^1.0"
+        "webmozart/assert": "^1.0",
+        "container-interop/service-provider": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.22",
-        "sllh/php-cs-fixer-styleci-bridge": "^1.5.0"
+        "sllh/php-cs-fixer-styleci-bridge": "^1.5.0",
+        "puli/cli":"^1.0-beta10",
+        "puli/composer-plugin": "^1.0-beta10"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/puli.json
+++ b/puli.json
@@ -1,0 +1,258 @@
+{
+    "version": "1.0",
+    "name": "acmephp/ssl",
+    "bindings": {
+        "665cebbb-328f-4890-bd59-ccc13e230d70": {
+            "_class": "Puli\\Discovery\\Binding\\ClassBinding",
+            "class": "AcmePhp\\Ssl\\DependencyInjection\\AcmeSslServiceProvider",
+            "type": "container-interop/service-provider"
+        }
+    },
+    "config": {
+        "bootstrap-file": "vendor/autoload.php"
+    },
+    "packages": {
+        "composer/semver": {
+            "install-path": "vendor/composer/semver",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "container-interop/container-interop": {
+            "install-path": "vendor/container-interop/container-interop",
+            "installer": "composer"
+        },
+        "container-interop/service-provider": {
+            "install-path": "vendor/container-interop/service-provider",
+            "installer": "composer"
+        },
+        "doctrine/instantiator": {
+            "install-path": "vendor/doctrine/instantiator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "justinrainbow/json-schema": {
+            "install-path": "vendor/justinrainbow/json-schema",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "padraic/humbug_get_contents": {
+            "install-path": "vendor/padraic/humbug_get_contents",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "padraic/phar-updater": {
+            "install-path": "vendor/padraic/phar-updater",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "paragonie/random_compat": {
+            "install-path": "vendor/paragonie/random_compat",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpdocumentor/reflection-docblock": {
+            "install-path": "vendor/phpdocumentor/reflection-docblock",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpspec/prophecy": {
+            "install-path": "vendor/phpspec/prophecy",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-code-coverage": {
+            "install-path": "vendor/phpunit/php-code-coverage",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-file-iterator": {
+            "install-path": "vendor/phpunit/php-file-iterator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-text-template": {
+            "install-path": "vendor/phpunit/php-text-template",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-timer": {
+            "install-path": "vendor/phpunit/php-timer",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/php-token-stream": {
+            "install-path": "vendor/phpunit/php-token-stream",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/phpunit": {
+            "install-path": "vendor/phpunit/phpunit",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "phpunit/phpunit-mock-objects": {
+            "install-path": "vendor/phpunit/phpunit-mock-objects",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "psr/log": {
+            "install-path": "vendor/psr/log",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/cli": {
+            "install-path": "vendor/puli/cli",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/composer-plugin": {
+            "install-path": "vendor/puli/composer-plugin",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/discovery": {
+            "install-path": "vendor/puli/discovery",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/manager": {
+            "install-path": "vendor/puli/manager",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/repository": {
+            "install-path": "vendor/puli/repository",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "puli/url-generator": {
+            "install-path": "vendor/puli/url-generator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "ramsey/uuid": {
+            "install-path": "vendor/ramsey/uuid",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/comparator": {
+            "install-path": "vendor/sebastian/comparator",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/diff": {
+            "install-path": "vendor/sebastian/diff",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/environment": {
+            "install-path": "vendor/sebastian/environment",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/exporter": {
+            "install-path": "vendor/sebastian/exporter",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/global-state": {
+            "install-path": "vendor/sebastian/global-state",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/recursion-context": {
+            "install-path": "vendor/sebastian/recursion-context",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sebastian/version": {
+            "install-path": "vendor/sebastian/version",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "seld/jsonlint": {
+            "install-path": "vendor/seld/jsonlint",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sllh/php-cs-fixer-styleci-bridge": {
+            "install-path": "vendor/sllh/php-cs-fixer-styleci-bridge",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "sllh/styleci-fixers": {
+            "install-path": "vendor/sllh/styleci-fixers",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/config": {
+            "install-path": "vendor/symfony/config",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/console": {
+            "install-path": "vendor/symfony/console",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/dependency-injection": {
+            "install-path": "vendor/symfony/dependency-injection",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/event-dispatcher": {
+            "install-path": "vendor/symfony/event-dispatcher",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/filesystem": {
+            "install-path": "vendor/symfony/filesystem",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/polyfill-mbstring": {
+            "install-path": "vendor/symfony/polyfill-mbstring",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/process": {
+            "install-path": "vendor/symfony/process",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "symfony/yaml": {
+            "install-path": "vendor/symfony/yaml",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/assert": {
+            "install-path": "vendor/webmozart/assert",
+            "installer": "composer"
+        },
+        "webmozart/console": {
+            "install-path": "vendor/webmozart/console",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/expression": {
+            "install-path": "vendor/webmozart/expression",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/glob": {
+            "install-path": "vendor/webmozart/glob",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/json": {
+            "install-path": "vendor/webmozart/json",
+            "installer": "composer",
+            "env": "dev"
+        },
+        "webmozart/path-util": {
+            "install-path": "vendor/webmozart/path-util",
+            "installer": "composer",
+            "env": "dev"
+        }
+    }
+}

--- a/src/DependencyInjection/AcmeSslServiceProvider.php
+++ b/src/DependencyInjection/AcmeSslServiceProvider.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the ACME PHP library.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Ssl\DependencyInjection;
+
+use AcmePhp\Ssl\Formatter\CertificateFormatter;
+use AcmePhp\Ssl\Formatter\CombinedFormatter;
+use AcmePhp\Ssl\Formatter\FullChainFormatter;
+use AcmePhp\Ssl\Formatter\IssuerChainFormatter;
+use AcmePhp\Ssl\Formatter\KeyPairFormatter;
+use AcmePhp\Ssl\Generator\KeyPairGenerator;
+use AcmePhp\Ssl\Parser\CertificateParser;
+use AcmePhp\Ssl\Signer\CertificateRequestSigner;
+use Interop\Container\ContainerInterface;
+use Interop\Container\ServiceProvider;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class AcmeSslServiceProvider implements ServiceProvider
+{
+    public static function getServices()
+    {
+        return [
+            // Formatters
+            KeyPairFormatter::class     => 'getKeyPairFormatter',
+            CertificateFormatter::class => 'getCertificateFormatter',
+            IssuerChainFormatter::class => 'getIssuerChainFormatter',
+            FullChainFormatter::class   => 'getFullChainFormatter',
+            CombinedFormatter::class    => 'getCombinedFormatter',
+
+            // Generators
+            KeyPairGenerator::class => 'getKeyPairGenerator',
+
+            // Parsers
+            CertificateParser::class => 'getCertificateParser',
+
+            // Signers
+            CertificateRequestSigner::class => 'getCertificateRequestSigner',
+        ];
+    }
+
+    /*
+     * Formatters
+     */
+
+    public static function getKeyPairFormatter()
+    {
+        return new KeyPairFormatter();
+    }
+
+    public static function getCertificateFormatter()
+    {
+        return new CertificateFormatter();
+    }
+
+    public static function getIssuerChainFormatter()
+    {
+        return new IssuerChainFormatter();
+    }
+
+    public static function getFullChainFormatter(ContainerInterface $container)
+    {
+        return new FullChainFormatter(
+            $container->get(CertificateFormatter::class),
+            $container->get(IssuerChainFormatter::class)
+        );
+    }
+
+    public static function getCombinedFormatter(ContainerInterface $container)
+    {
+        return new CombinedFormatter(
+            $container->get(FullChainFormatter::class),
+            $container->get(KeyPairFormatter::class)
+        );
+    }
+
+    /*
+     * Generators
+     */
+
+    public static function getKeyPairGenerator()
+    {
+        return new KeyPairGenerator();
+    }
+
+    /*
+     * Signers
+     */
+
+    public static function getCertificateRequestSigner()
+    {
+        return new CertificateRequestSigner();
+    }
+
+    /*
+     * Parsers
+     */
+
+    public static function getCertificateParser()
+    {
+        return new CertificateParser();
+    }
+}


### PR DESCRIPTION
While I'm working on the new architecture of the core in https://github.com/acmephp/core/pull/7, I'm realizing we start to have quite a lot of different services. In this SSL library only, we have formatters, generators, parsers and signers (and if we merge the two other PRs, we will create even more of them).

The problem when we have a lot of services like that is to encapsulatee all of them. If we want to keep things extensible, we have to encapsulate the service in the client, but this will be a mess (there will be way too much parameters in the constructor).

To solve this issue, I propose the usage of a very simple dependency injection container in the core (built by the PHP League: http://container.thephpleague.com). What's great with this container is that it follows the [container-interop initiative](https://github.com/container-interop/) and therefore can be included in an application container very easily (and the problem of having two containers disappear).

In this PR, I implement a container-interop service provider for the services proposed by the SSL library. This way, we will be able to load these service very easily from the core and people using a [compatible container](https://github.com/container-interop/container-interop#projects-implementing-containerinterface) will be able to use these services also very easily.

In addition to that, I included Puli so that people using Puli in their project would benefit from automatic service loading in their app container (without the need to use the service provider).
